### PR TITLE
fix: support optional boundspec for array type

### DIFF
--- a/src/express/datatype.rs
+++ b/src/express/datatype.rs
@@ -21,7 +21,7 @@ pub enum DataType {
         name: String,
     },
     Array {
-        bound: BoundSpec,
+        bound: Option<BoundSpec>,
         optional: bool,
         unique: bool,
         base_type: Box<DataType>,

--- a/src/express/parser.rs
+++ b/src/express/parser.rs
@@ -138,7 +138,7 @@ fn bound_spec<'a>() -> Parser<'a, u8, BoundSpec> {
 }
 
 fn aggregation_data_type<'a>() -> Parser<'a, u8, DataType> {
-    (keyword("array") * space() * bound_spec() - space() - keyword("of") - space()
+    (keyword("array") * space() * bound_spec().opt() - space() - keyword("of") - space()
         + (keyword("optional") - space()).opt()
         + (keyword("unique") - space()).opt()
         + call(base_data_type))


### PR DESCRIPTION
resolve the issue ["Conversion Error is prompted while running codegen for ifc4.exp"](https://github.com/J-F-Liu/iso-10303/pull/2) by making DataType::Array::bound be optional.

``` rust
pub enum DataType {
   Array {
        bound: Option<BoundSpec>,
   },
   //...
}

```